### PR TITLE
chore: release necessary files only

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "8.2.0-alpha1",
   "description": "Zeebe CLI",
   "main": "index.js",
+  "files": [
+    "/bin"
+  ],
   "bin": {
     "zbctl": "bin/zbctl",
     "zbctl-cli.darwin": "bin/zbctl-cli.darwin",


### PR DESCRIPTION
This adds "files" field in package.json which ensures only `bin` is shipped. No need to upload GH workflows or test files to NPM.

```diff
--- 1	2023-01-26 14:35:06.000000000 +0100
+++ 2	2023-01-26 14:34:57.000000000 +0100
@@ -2,23 +2,20 @@
 npm notice
 npm notice 📦  zbctl@8.2.0-alpha1
 npm notice === Tarball Contents ===
-npm notice 811B    .github/workflows/release.yml
-npm notice 130B    Dockerfile
-npm notice 4.7kB   README.md
-npm notice 1.3kB   bin/zbctl
-npm notice 12.4MB  bin/zbctl-cli.darwin
-npm notice 12.6MB  bin/zbctl-cli.exe
-npm notice 12.5MB  bin/zbctl-cli.linux
-npm notice 223.7kB certs/ca-certificates.crt
-npm notice 822B    package.json
+npm notice 4.7kB  README.md
+npm notice 1.3kB  bin/zbctl
+npm notice 12.4MB bin/zbctl-cli.darwin
+npm notice 12.6MB bin/zbctl-cli.exe
+npm notice 12.5MB bin/zbctl-cli.linux
+npm notice 851B   package.json
 npm notice === Tarball Details ===
 npm notice name:          zbctl
 npm notice version:       8.2.0-alpha1
 npm notice filename:      zbctl-8.2.0-alpha1.tgz
-npm notice package size:  13.2 MB
-npm notice unpacked size: 37.7 MB
-npm notice shasum:        984254d206d96a26f43e95af0fe5a9efa421e5cd
-npm notice integrity:     sha512-wrlWemmwJWjct[...]PKrSONpNbasjw==
-npm notice total files:   9
+npm notice package size:  13.1 MB
+npm notice unpacked size: 37.5 MB
+npm notice shasum:        224ae071013c32257f8b1393545c2d5f205cb347
+npm notice integrity:     sha512-8Dq5YvkM8P+lB[...]+xgRjIOmJHF8g==
+npm notice total files:   6
 npm notice
 zbctl-8.2.0-alpha1.tgz
```